### PR TITLE
Add default 503 status code + option to override in config

### DIFF
--- a/MaintenanceMode.php
+++ b/MaintenanceMode.php
@@ -88,6 +88,14 @@ class MaintenanceMode extends Component
     public $usernameAttribute = 'username';
 
     /**
+     * Default status code to send on maintenance
+     *
+     * 503 = Service Unavailable
+     * @var int
+     */
+    public $statusCode = 503;
+
+    /**
      * Disable items.
      * @var
      */
@@ -100,6 +108,15 @@ class MaintenanceMode extends Component
     {
 
         if ($this->enabled) {
+
+            if($this->statusCode) {
+                if(is_integer($this->statusCode)) {
+                    Yii::$app->getResponse()->setStatusCode($this->statusCode);
+                }
+                else {
+                    throw new InvalidConfigException('Parameter "statusCode" should be an integer.');
+                }
+            }
 
             if($this->users) {
                 if(is_array($this->users)) {

--- a/README.md
+++ b/README.md
@@ -73,5 +73,8 @@ Add to your config file:
   // User name attribute name
   'usernameAttribute'=>'login',
   
+  // HTTP Status Code
+  'statusCode'=>503,
+  
 ],
 ```


### PR DESCRIPTION
503 code tells search engines that the resource is temporary unavailable, so it won't impact the SEO scores negatively (if the maintenance won't take too long ofcourse). The pages indexed won't be affected while performing maintenance.
