### PR TITLE
Update composer.json - remove slash from autoload / psr-4 definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "autoload": {
         "psr-4": {
-            "brussens\\maintenance\\": "/src"
+            "brussens\\maintenance\\": "src"
         }
     }
 }


### PR DESCRIPTION
I suggest to remove slash from autoload 'src' definition because it's giving an error with open_basedir

`open_basedir restriction in effect. File(/src/Maintenance.php) is not within the allowed path(s):`